### PR TITLE
Increase rendered whitespace contrast

### DIFF
--- a/themes/Mirage-color-theme.json
+++ b/themes/Mirage-color-theme.json
@@ -27,7 +27,7 @@
 			"editorGroupHeader.tabsBackground": "#182333",
 			"editorIndentGuide.background": "#1E2C3F",
 			"editorLineNumber.foreground": "#2C415C95",
-			"editorWhitespace.foreground": "#1E2C3F",
+			"editorWhitespace.foreground": "#2B3E5A",
 			"editorHoverWidget.background": "#182333",
 			"editorHoverWidget.border": "#1E2C3F",
 			"editorSuggestWidget.background": "#182333",


### PR DESCRIPTION
This slightly increases the contrast of rendered whitespace (#7). The current color works for indent guides, etc. But it is essentially invisible for smaller glyphs.

I just used an HSL picker to slightly increase the lightness, leaving the hue and saturation untouched.

So, instead of this:
<img width="253" alt="screen shot 2017-11-10 at 8 03 54 am" src="https://user-images.githubusercontent.com/2547860/32661927-587eca16-c5ee-11e7-98cc-e19734575e9f.png">

We get this:
<img width="262" alt="screen shot 2017-11-10 at 8 03 27 am" src="https://user-images.githubusercontent.com/2547860/32661937-5fdc7f10-c5ee-11e7-88f3-5693b46aac08.png">

Thanks for the awesome theme! 🙌