### PR TITLE
Add contrasting titleBar.activeForeground

### DIFF
--- a/themes/Mirage-color-theme.json
+++ b/themes/Mirage-color-theme.json
@@ -59,7 +59,7 @@
 			"tab.border": "#1B2738",
 			"tab.inactiveBackground": "#182333",
 			"titleBar.activeBackground": "#273951",
-			"titleBar.activeForeground": "#273951",
+			"titleBar.activeForeground": "#C8D5E4",
 			"titleBar.inactiveBackground": "#273951",
 			"titleBar.inactiveForeground": "#5E82B3",
 			"extensionButton.prominentForeground": "#182333",

--- a/themes/Mirage-high-contrast-color-theme.json
+++ b/themes/Mirage-high-contrast-color-theme.json
@@ -59,7 +59,7 @@
 			"tab.border": "#1B2738",
 			"tab.inactiveBackground": "#182333",
 			"titleBar.activeBackground": "#273951",
-			"titleBar.activeForeground": "#273951",
+			"titleBar.activeForeground": "#C8D5E4",
 			"titleBar.inactiveBackground": "#273951",
 			"titleBar.inactiveForeground": "#5E82B3",
 			"extensionButton.prominentForeground": "#182333",

--- a/themes/Mirage-pastel-color-theme.json
+++ b/themes/Mirage-pastel-color-theme.json
@@ -59,7 +59,7 @@
 			"tab.border": "#1B2738",
 			"tab.inactiveBackground": "#182333",
 			"titleBar.activeBackground": "#273951",
-			"titleBar.activeForeground": "#273951",
+			"titleBar.activeForeground": "#C8D5E4",
 			"titleBar.inactiveBackground": "#273951",
 			"titleBar.inactiveForeground": "#5E82B3",
 			"extensionButton.prominentForeground": "#182333",


### PR DESCRIPTION
When using the custom title bar on MacOS, the background and foreground are currently the same color. This adds a lighter color for the foreground.

From this:
<img width="301" alt="screen shot 2017-11-11 at 6 50 45 pm" src="https://user-images.githubusercontent.com/2547860/32694862-44c828b8-c711-11e7-8af8-ada372ac9131.png">

To this:
<img width="376" alt="screen shot 2017-11-11 at 6 50 27 pm" src="https://user-images.githubusercontent.com/2547860/32694869-4b48c832-c711-11e7-8f83-62a8eda87bdc.png">

